### PR TITLE
Logic correction

### DIFF
--- a/Form1.cs
+++ b/Form1.cs
@@ -52,22 +52,22 @@ namespace Activities
             {
                 case "Add":
                     {
-                        sum = number1 - number2;
+                        sum = number1 + number2;
                         break;
                     }
                 case "Subtract":
                     {
-                        sum = number1 + number2;
+                        sum = number1 - number2;
                         break;
                     }
                 case "Multiply":
                     {
-                        sum = number1 / number2;
+                        sum = number1 * number2;
                         break;
                     }
                 case "Divide":
                     {
-                        sum = number1 * number2;
+                        sum = number1 / number2;
                         break;
                     }
                 case "Modulus":


### PR DESCRIPTION
I have fixed the bug which has caused incorrect sum calculation. This occurred on the Add, Subtract, Multiply and Divide buttons when calculating the answer. Now when pressing those buttons, the correct calculations are made. 